### PR TITLE
Allow Multiple User RVM

### DIFF
--- a/models/rvm_wrapper.rb
+++ b/models/rvm_wrapper.rb
@@ -44,7 +44,7 @@ class RvmWrapper < Jenkins::Tasks::BuildWrapper
 
       if k=="PATH" then
         # look for PATH components that include "rvm" and pick those up
-        path = v.split(File::PATH_SEPARATOR).find_all{|p| p =~ /[\\\/]\rvm[\\\/]/ }.join(File::PATH_SEPARATOR)
+        path = v.split(File::PATH_SEPARATOR).find_all{|p| p =~ /[\\\/]rvm[\\\/]/ }.join(File::PATH_SEPARATOR)
         build.env["PATH+RVM"] = path
         #listener.debug "Adding PATH+RVM=#{path}"
       else


### PR DESCRIPTION
This will allow RVM, installed as root so that it may be used by multiple users, to have the correct path when sourcing the startup script.

This is necessary if RVM is to work with the EC2 plugin.
