### PR TITLE
Error during jenkins startup when trying to register_extension.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source :rubygems
 
-gem 'jenkins-plugin-runtime', '~> 0.1.17'
+gem 'jenkins-plugin-runtime', '~> 0.2.2'
 
 group :development do
-  gem 'jpi', '~> 0.3.1'
+  gem 'jpi', '~> 0.3.7'
 end

--- a/rvm.pluginspec
+++ b/rvm.pluginspec
@@ -7,5 +7,5 @@ Jenkins::Plugin::Specification.new do |plugin|
   plugin.developed_by 'kohsuke', 'kk@kohsuke.org'
   plugin.uses_repository :github => 'rvm-plugin'
 
-  plugin.depends_on 'ruby-runtime', '0.7'
+  plugin.depends_on 'ruby-runtime', '0.10'
 end


### PR DESCRIPTION
The error seen doing a jpi server:

Loading /Users/rteabeault/projects/rvm-plugin/models/rvm_wrapper.rb
ArgumentError: wrong number of arguments (2 for 1)
/Users/rteabeault/.rvm/gems/jruby-1.6.7.2/gems/jenkins-plugin-runtime-0.1.27/lib/jenkins/plugin.rb:116:in `register_extension'
