### PR TITLE
Fix rvm_wrapper transient variables

### DIFF
--- a/models/rvm_wrapper.rb
+++ b/models/rvm_wrapper.rb
@@ -8,8 +8,8 @@ class RvmWrapper < Jenkins::Tasks::BuildWrapper
   DEFAULT_IMPL = '.'
 
   class << self
-    def transient?(symbol)
-      [:rvm_path, :launcher].include?(symbol)
+    def transient?(property)
+      [:rvm_path, :launcher].include?(property.to_sym)
     end
   end
 


### PR DESCRIPTION
The transient? method is passed a string, not a symbol, as far as I can tell.

This appears to fix JENKINS-18841 for me so far (the bug is sometimes hard to reproduce).

See:
https://github.com/jenkinsci/jruby-xstream/blob/master/src/main/java/org/jenkinsci/jruby/JRubyXStreamConverter.java#L61
