### PR TITLE
changed project/buildWrappers/ruby-proxy-object to */buildWrappers/ruby-...

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ After updating RVM plugin, you *need to update* your project's configuration fil
  ```
 
 The update script renames original configuration file to `<original file name>.bak` in case update fails.
+
+
+Contributors:
+[Daniel Foglio](https://github.com/danielfoglio)

--- a/bin/convert.rb
+++ b/bin/convert.rb
@@ -30,7 +30,7 @@ def convert(config_file)
   new_config = nil
   File.open(config_file, 'r') do |file|
     doc = REXML::Document.new(file)
-    doc.elements.each('project/buildWrappers/ruby-proxy-object') do |proxy_object|
+    doc.elements.each('*/buildWrappers/ruby-proxy-object') do |proxy_object|
       rewrite_proxy_class_name(proxy_object)
       remove_unwanted_serialized_attributes(proxy_object)
     end


### PR DESCRIPTION
...proxy-object as we cannot speculate project is the root node, for example it could be maven2-moduleset