### PR TITLE
(Partial) fix for bug around RVM detection.

### DIFF
--- a/models/rvm_wrapper.rb
+++ b/models/rvm_wrapper.rb
@@ -16,7 +16,7 @@ class RvmWrapper < Jenkins::Tasks::BuildWrapper
   end
 
   def rvm_path
-    @rvm_path ||= ["~/.rvm/scripts/rvm", "/usr/local/rvm/scripts/rvm"].find do |path|
+    @rvm_path = ["~/.rvm/scripts/rvm", "/usr/local/rvm/scripts/rvm"].find do |path|
       @launcher.execute("bash", "-c", "test -f #{path}") == 0
     end
   end


### PR DESCRIPTION
When running multiple Jenkins build agents (slaves), particularly if
these are created and destroyed independently of the master instance,
the caching of the `rvm_path` on the master prevents the absence of
on `rvm` installation on the current slave being detected.

Note that the value is still being held globally, so two concurrently
executing jobs still have the potential to fail to detect the presence
of `rvm`, though the likelihood is deminished.